### PR TITLE
feat: Implement reporting metrics and generation

### DIFF
--- a/app/reporting/metrics_calculator.py
+++ b/app/reporting/metrics_calculator.py
@@ -1,0 +1,113 @@
+import numpy as np
+
+def calculate_sharpe_ratio(returns: list[float], risk_free_rate: float) -> float:
+    """
+    Calculates the Sharpe ratio, a measure of risk-adjusted return.
+
+    Args:
+        returns (list[float]): A list of portfolio returns (e.g., daily, weekly).
+        risk_free_rate (float): The risk-free rate of return for the same period as returns.
+
+    Returns:
+        float: The calculated Sharpe ratio.
+               Returns 0.0 if the standard deviation of returns is zero and the mean excess return is also zero.
+               Returns float('inf') or float('-inf') if the standard deviation is zero and the mean excess return is non-zero.
+
+    Raises:
+        ValueError: If the `returns` list is empty.
+    """
+    if not returns:
+        raise ValueError("Returns list cannot be empty.")
+
+    returns_array = np.array(returns)
+    mean_return = np.mean(returns_array)
+    std_dev_returns = np.std(returns_array)
+
+    if std_dev_returns == 0:
+        excess_return = mean_return - risk_free_rate
+        if excess_return == 0:
+            return 0.0
+        elif excess_return > 0:
+            return float('inf')
+        else:
+            return float('-inf')
+
+    sharpe_ratio = (mean_return - risk_free_rate) / std_dev_returns
+    return sharpe_ratio
+
+def calculate_max_drawdown(prices: list[float]) -> float:
+    """
+    Calculates the maximum drawdown from a list of prices.
+    Maximum drawdown is the largest peak-to-trough decline during a specific period.
+
+    Args:
+        prices (list[float]): A list of asset prices in chronological order.
+
+    Returns:
+        float: The maximum drawdown as a positive percentage (e.g., 0.1 for 10% drawdown).
+               Returns 0.0 if the `prices` list is empty or contains only one element.
+
+    Raises:
+        ValueError: If the `prices` list is empty (explicitly checked, though `len(prices) <= 1` also covers it).
+    """
+    if not prices:
+        raise ValueError("Prices list cannot be empty.")
+
+    if len(prices) <= 1:
+        return 0.0
+
+    prices_array = np.array(prices)
+    peak = prices_array[0]
+    max_drawdown = 0.0
+
+    for price in prices_array:
+        if price > peak:
+            peak = price
+        drawdown = (peak - price) / peak
+        if drawdown > max_drawdown:
+            max_drawdown = drawdown
+
+    return max_drawdown
+
+def calculate_sortino_ratio(returns: list[float], risk_free_rate: float, target_return: float = 0.0) -> float:
+    """
+    Calculates the Sortino ratio, a variation of the Sharpe ratio that differentiates harmful volatility from total overall volatility
+    by using the asset's standard deviation of negative asset returns—downside deviation—instead of the total standard deviation of portfolio returns.
+
+    Args:
+        returns (list[float]): A list of portfolio returns.
+        risk_free_rate (float): The risk-free rate of return.
+        target_return (float, optional): The minimum acceptable return, used to calculate downside deviation. Defaults to 0.0.
+
+    Returns:
+        float: The calculated Sortino ratio.
+               Returns 0.0 if the downside deviation is zero and the mean excess return (over risk-free rate) is also zero.
+               Returns float('inf') or float('-inf') if the downside deviation is zero and the mean excess return is non-zero.
+
+    Raises:
+        ValueError: If the `returns` list is empty.
+    """
+    if not returns:
+        raise ValueError("Returns list cannot be empty.")
+
+    returns_array = np.array(returns)
+    mean_return = np.mean(returns_array)
+
+    downside_returns = returns_array[returns_array < target_return]
+
+    if not downside_returns.any(): # Handles cases where all returns are >= target_return
+        downside_deviation = 0.0
+    else:
+        downside_deviation = np.std(downside_returns)
+
+    if downside_deviation == 0:
+        excess_return = mean_return - risk_free_rate
+        if excess_return == 0: # Adjusted to compare with risk_free_rate as per common Sortino definition
+            return 0.0
+        elif excess_return > 0:
+            return float('inf')
+        else:
+            return float('-inf')
+
+    sortino_ratio = (mean_return - risk_free_rate) / downside_deviation
+    return sortino_ratio

--- a/app/reporting/report_generator.py
+++ b/app/reporting/report_generator.py
@@ -1,0 +1,105 @@
+def _format_metric_name(metric_key: str) -> str:
+    """
+    Converts a metric key string (e.g., 'sharpe_ratio') into a more readable
+    title-cased string (e.g., 'Sharpe Ratio').
+
+    Args:
+        metric_key (str): The metric key to format.
+
+    Returns:
+        str: The formatted, human-readable metric name.
+    """
+    return ' '.join(word.capitalize() for word in metric_key.split('_'))
+
+def generate_text_report(metrics: dict[str, float], strategy_name: str) -> str:
+    """
+    Generates a simple text-based report summarizing a trading strategy's performance metrics.
+
+    The report lists each metric name and its value. 'max_drawdown' is presented as a percentage.
+    Other float values are formatted to two decimal places. If the metrics dictionary is empty,
+    a message indicating no available metrics is returned.
+
+    Args:
+        metrics (dict[str, float]): A dictionary where keys are metric names (e.g., 'sharpe_ratio')
+                                     and values are the corresponding float values.
+        strategy_name (str): The name of the trading strategy.
+
+    Returns:
+        str: A string formatted as a multi-line text report.
+             Example:
+             Strategy Performance Report: MyStrategy
+             -------------------------------------------
+             Sharpe Ratio: 1.50
+             Maximum Drawdown: 10.00%
+             -------------------------------------------
+    """
+    if not metrics:
+        return f"No metrics available for strategy: {strategy_name}"
+
+    report_lines = [
+        f"Strategy Performance Report: {strategy_name}",
+        "-------------------------------------------"
+    ]
+
+    for key, value in metrics.items():
+        readable_name = _format_metric_name(key)
+        if key == 'max_drawdown':
+            report_lines.append(f"{readable_name}: {value * 100:.2f}%")
+        else:
+            report_lines.append(f"{readable_name}: {value:.2f}")
+
+    report_lines.append("-------------------------------------------")
+    return "\n".join(report_lines)
+
+def generate_html_report(metrics: dict[str, float], strategy_name: str) -> str:
+    """
+    Generates a basic HTML report summarizing a trading strategy's performance metrics.
+
+    The report displays the metrics in an HTML table. 'max_drawdown' is presented as a percentage.
+    Other float values are formatted to two decimal places. If the metrics dictionary is empty,
+    a paragraph indicating no available metrics is returned.
+
+    Args:
+        metrics (dict[str, float]): A dictionary where keys are metric names (e.g., 'sharpe_ratio')
+                                     and values are the corresponding float values.
+        strategy_name (str): The name of the trading strategy.
+
+    Returns:
+        str: A string containing the HTML report.
+             Includes a title, header, and a table for metrics.
+             Example table row: <tr><td>Sharpe Ratio</td><td>1.50</td></tr>
+    """
+    if not metrics:
+        return f"<p>No metrics available for strategy: {strategy_name}</p>"
+
+    html_rows = []
+    for key, value in metrics.items():
+        readable_name = _format_metric_name(key)
+        if key == 'max_drawdown':
+            formatted_value = f"{value * 100:.2f}%"
+        else:
+            formatted_value = f"{value:.2f}"
+        html_rows.append(f"  <tr><td>{readable_name}</td><td>{formatted_value}</td></tr>")
+
+    html_table = "\n".join(html_rows)
+
+    return f"""<!DOCTYPE html>
+<html>
+<head>
+<title>Strategy Performance Report: {strategy_name}</title>
+<style>
+  table {{ font-family: arial, sans-serif; border-collapse: collapse; width: 50%; margin-left: auto; margin-right: auto; }}
+  td, th {{ border: 1px solid #dddddd; text-align: left; padding: 8px; }}
+  tr:nth-child(even) {{ background-color: #f2f2f2; }}
+  h2 {{ text-align: center; }}
+</style>
+</head>
+<body>
+<h2>Strategy Performance Report: {strategy_name}</h2>
+<table>
+  <tr><th>Metric</th><th>Value</th></tr>
+{html_table}
+</table>
+</body>
+</html>
+"""


### PR DESCRIPTION
Implemented core functionality for the reporting module:

- In `app/reporting/metrics_calculator.py`:
    - Added `calculate_sharpe_ratio` to compute Sharpe ratio.
    - Added `calculate_max_drawdown` to compute maximum drawdown.
    - Added `calculate_sortino_ratio` to compute Sortino ratio.
    - All functions include docstrings, type hints, and handle edge cases such as empty input lists or potential division by zero.

- In `app/reporting/report_generator.py`:
    - Added `generate_text_report` to create a plain text summary of performance metrics.
    - Added `generate_html_report` to create an HTML summary of performance metrics.
    - Both functions include docstrings, type hints, handle empty metric inputs, and format metric names and values (e.g., drawdown as percentage).

Ensured all necessary imports (like numpy) are present and updated type hints to use modern built-in generics (e.g., `dict` instead of `typing.Dict` for Python 3.9+).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added functions to calculate key financial performance metrics: Sharpe ratio, maximum drawdown, and Sortino ratio.
	- Introduced text and HTML report generators for summarizing trading strategy performance metrics in a user-friendly format. Reports display metrics with clear formatting and handle empty data gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->