### PR TITLE
Add spread calculator tests

### DIFF
--- a/tests/test_spread_calculator.py
+++ b/tests/test_spread_calculator.py
@@ -1,0 +1,48 @@
+import numpy as np
+import pytest
+from collections import deque
+from app.services.spread_calculator import SpreadCalculator
+
+
+def test_calculate_spread_computes_indicators_correctly():
+    calc = SpreadCalculator()
+    # simulate 50 ticks with increasing spread value
+    last_data = None
+    for i in range(1, 51):
+        last_data = calc.calculate_spread("A", 100 + i, "B", 100)
+
+    assert last_data.spread == 50
+    assert last_data.spread_percentage == pytest.approx(50.0)
+
+    expected_ma20 = np.mean(np.arange(31, 51))
+    expected_ma50 = np.mean(np.arange(1, 51))
+    expected_z = (50 - np.mean(np.arange(31, 51))) / np.std(np.arange(31, 51))
+
+    assert last_data.ma_20 == pytest.approx(expected_ma20)
+    assert last_data.ma_50 == pytest.approx(expected_ma50)
+    assert last_data.z_score == pytest.approx(expected_z)
+
+
+def test__calculate_indicators_returns_expected_values():
+    calc = SpreadCalculator()
+    pair_key = "X_Y"
+    data = list(range(1, 51))
+    calc.spread_history[pair_key] = deque(data, maxlen=calc.lookback_period)
+
+    ma20, ma50, z = calc._calculate_indicators(pair_key)
+
+    assert ma20 == pytest.approx(np.mean(data[-20:]))
+    assert ma50 == pytest.approx(np.mean(data[-50:]))
+    expected_z = (data[-1] - np.mean(data[-20:])) / np.std(data[-20:])
+    assert z == pytest.approx(expected_z)
+
+
+def test__calculate_indicators_insufficient_data():
+    calc = SpreadCalculator()
+    pair_key = "A_B"
+    data = [1, 2, 3]
+    calc.spread_history[pair_key] = deque(data, maxlen=calc.lookback_period)
+
+    ma20, ma50, z = calc._calculate_indicators(pair_key)
+
+    assert ma20 is None and ma50 is None and z is None


### PR DESCRIPTION
## Summary
- add tests for spread calculation
- verify MA and Z-score computations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68418408cd08832187bc4d23eac454a5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added new tests to validate spread calculations, moving averages, and z-score computations for the spread calculator, including checks for normal and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->