### PR TITLE
Fix unrealized PnL calculation

### DIFF
--- a/app/services/backtesting_service.py
+++ b/app/services/backtesting_service.py
@@ -187,7 +187,9 @@ class BacktestingService:
                 
                 # Track max favorable/adverse moves
                 current_pnl_points = self._calculate_pnl_points(
-                    current_trade, row['spread'], row['spread']
+                    current_trade,
+                    current_trade.entry_spread,
+                    row['spread']
                 )
                 
                 if current_pnl_points > current_trade.max_favorable_move:


### PR DESCRIPTION
## Summary
- correctly compute unrealized PnL in `simulate_trades`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841840590408321aff622a9cf481f5e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the calculation of profit and loss (P&L) during open trades to ensure more accurate results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->