### PR TITLE
Fix import comment

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, HTTPException, Depends
-from typing import Dict, List, Optional  # Add Optional here
+from typing import Dict, List, Optional
 
 from ..models.trading import StrategyStatus
 from ..services.trading_strategy import PairTradingStrategy


### PR DESCRIPTION
## Summary
- remove placeholder comment from routes imports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68418403d59c8321bf5127c842821818