### PR TITLE
Fix backtest PnL tracking

### DIFF
--- a/app/services/backtesting_service.py
+++ b/app/services/backtesting_service.py
@@ -187,7 +187,9 @@ class BacktestingService:
                 
                 # Track max favorable/adverse moves
                 current_pnl_points = self._calculate_pnl_points(
-                    current_trade, row['spread'], row['spread']
+                    current_trade,
+                    current_trade.entry_spread,
+                    row['spread']
                 )
                 
                 if current_pnl_points > current_trade.max_favorable_move:


### PR DESCRIPTION
## Summary
- fix current PnL calculation when simulating trades

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684182288a548321a15190143f766288