### PR TITLE
Fix instruments search route decorator

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -166,7 +166,7 @@ async def get_spread_history(
     }
 
 
-router.get("/instruments/search")
+@router.get("/instruments/search")
 async def search_instruments(
     query: str,
     exchange: str = "NFO",


### PR DESCRIPTION
## Summary
- add missing decorator for `/instruments/search` endpoint in `routes.py`

## Testing
- `pytest -q`
- `flake8` *(fails: many style errors)*

------
https://chatgpt.com/codex/tasks/task_e_6841861cca2483219602ac5059e5220c